### PR TITLE
Allow user to change frequency

### DIFF
--- a/Source/Calculators/NoteCalculator.swift
+++ b/Source/Calculators/NoteCalculator.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct NoteCalculator {
   public struct Standard {
-    public static let frequency = 440.0
+    public static var frequency = 440.0
     public static let octave = 4
   }
 


### PR DESCRIPTION
Not each instrument is created equal and some musicians like to tune to 442, which is why this change is necessary to make the NoteCalculator.Standard.frequency customizable. 