### PR TITLE
Update SwiftPM support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble",
+        "state": {
+          "branch": null,
+          "revision": "b7f6c49acdb247e3158198c5448b38c3cc595533",
+          "version": "11.2.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick",
+        "state": {
+          "branch": null,
+          "revision": "16910e406be96e08923918315388c3e989deac9e",
+          "version": "6.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,23 @@
+// swift-tools-version:5.5.0
+
 import PackageDescription
 
 let package = Package(
-  name: "Pitchy"
+  name: "Pitchy",
+  products: [
+    .library(name: "Pitchy", targets: ["Pitchy"])
+  ],
+  dependencies: [
+    .package(url: "https://github.com/Quick/Quick", from: "6.1.0"),
+    .package(url: "https://github.com/Quick/Nimble", from: "11.2.1"),
+  ],
+  targets: [
+    .target(name: "Pitchy", dependencies: [], path: "Source"),
+    .testTarget(
+      name: "PitchyTests",
+      dependencies: ["Pitchy", "Quick", "Nimble"],
+      path: "PitchyTests",
+      exclude: [ "Mac/Info.plist", "iOS/Info.plist" ]
+    ),
+  ]
 )


### PR DESCRIPTION
# Summary

This PR updates the package definition for using this library as a Swift package.

# Description

- Provided a swift-tools-version
- Created a library product 
- Added support for running the tests using SwiftPM CLI

# How to test it?

- [ ] Try doing a build and running the tests with `swift build` and `swift test`
- [ ] Try including it in another project using SwiftPM
